### PR TITLE
Fix jsPDF autoTable integration for PDF exports

### DIFF
--- a/src/lib/invoiceUtils.js
+++ b/src/lib/invoiceUtils.js
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import { v4 as uuidv4 } from 'uuid';
 import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 
 export const initialInvoiceState = () => ({
   meta: {
@@ -39,6 +39,11 @@ const formatCurrency = (value) => new Intl.NumberFormat('en-GB', {
   style: 'currency',
   currency: 'GBP',
 }).format(Number(value) || 0);
+
+const runAutoTable = (doc, options) => {
+  autoTable(doc, options);
+  return doc.lastAutoTable?.finalY ?? autoTable.previous?.finalY ?? options.startY ?? 0;
+};
 
 export const exportToPDF = async (invoice, calculatedTotals) => {
   try {
@@ -104,7 +109,7 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
       ['', ''],
     ];
 
-    doc.autoTable({
+    runAutoTable(doc, {
         startY: 95,
         body: metaContent,
         theme: 'plain',
@@ -112,8 +117,8 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
         columnStyles: { 0: { fontStyle: 'bold', cellWidth: 30, textColor: GOLD } },
         tableWidth: (pageWidth / 2) - 14 - 2,
     });
-    
-    doc.autoTable({
+
+    runAutoTable(doc, {
         startY: 95,
         body: metaContent2,
         theme: 'plain',
@@ -123,7 +128,7 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
         margin: { left: pageWidth / 2 + 2 },
     });
 
-    let lastY = doc.autoTable.previous.finalY;
+    let lastY = doc.lastAutoTable?.finalY ?? 95;
 
     for (const section of invoice.sections) {
       doc.setFont('helvetica', 'bold');
@@ -147,7 +152,7 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
           ? section.items.map(item => [item.name, item.notes, item.price ? formatCurrency(Number(item.price)) : formatCurrency(0)])
           : section.items.map(item => [item.name, item.notes, '']);
       
-      doc.autoTable({
+      const sectionFinalY = runAutoTable(doc, {
         startY: lastY + 18,
         head: [['Item', 'Notes', 'Price']],
         body: bodyData,
@@ -163,7 +168,7 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
           }
         },
       });
-      lastY = doc.autoTable.previous.finalY + 10;
+      lastY = sectionFinalY + 10;
     }
 
     const startYForTotals = lastY + 10;
@@ -195,7 +200,7 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
       [{ content: 'Amount Due', styles: { halign: 'right', fontStyle: 'bold', textColor: BLACK, fontSize: 14 } }, { content: formatCurrency(calculatedTotals.amountDue), styles: { fontStyle: 'bold', fontSize: 14, textColor: BLACK } }], // Changed to Amount Due
     ];
 
-    doc.autoTable({
+    lastY = runAutoTable(doc, {
       startY: lastY,
       head: [[{content:'Invoice Summary', colSpan: 2, styles:{halign:'center', fontStyle:'bold', fillColor:GOLD, textColor:BLACK}}]], // Changed to Invoice Summary
       body: totalsData,
@@ -210,10 +215,8 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
         }
       },
     });
-    
-    lastY = doc.autoTable.previous.finalY;
 
-    doc.autoTable({
+    lastY = runAutoTable(doc, {
         startY: lastY,
         body: finalTotals,
         theme: 'grid',
@@ -232,13 +235,13 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
         },
     });
     
-    lastY = doc.autoTable.previous.finalY;
-    
+    let paymentStartY = lastY + 10;
+
     if (invoice.totals.showCostPerHead && calculatedTotals.costPerHead > 0) {
       const costPerHeadData = [
         [{ content: 'Cost Per Head', styles: { fontStyle: 'bold', textColor: BLACK } }, { content: formatCurrency(calculatedTotals.costPerHead), styles: { textColor: BLACK } }]
       ];
-      doc.autoTable({
+      const costPerHeadFinalY = runAutoTable(doc, {
         startY: lastY + 5,
         body: costPerHeadData,
         theme: 'grid',
@@ -251,10 +254,11 @@ export const exportToPDF = async (invoice, calculatedTotals) => {
           }
         },
       });
+      paymentStartY = costPerHeadFinalY + 10;
     }
 
     // Payment Details
-    lastY = doc.autoTable.previous.finalY + 10;
+    lastY = paymentStartY;
     if (lastY + 30 > pageHeight) {
       doc.addPage();
       drawPageTemplate(false);

--- a/src/pages/resources/BudgetCalculator.jsx
+++ b/src/pages/resources/BudgetCalculator.jsx
@@ -8,6 +8,7 @@ import { useToast } from '@/components/ui/use-toast';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import PageHeader from '@/components/PageHeader';
 import { generatePdfWithHeaderFooter } from '@/lib/pdfUtils';
+import autoTable from 'jspdf-autotable';
 
 const BudgetCalculator = () => {
   const { toast } = useToast();
@@ -90,7 +91,7 @@ const BudgetCalculator = () => {
       doc.text(`Guest Count: ${guestCount}`, 14, 38);
 
       const perHeadData = perHeadItems.map(item => [item.name, formatCurrency(item.cost), item.enabled ? 'Yes' : 'No', formatCurrency(item.enabled ? item.cost * guestCount : 0)]);
-      doc.autoTable({
+      autoTable(doc, {
         startY: 45,
         head: [['Per Head Items', 'Cost/Head', 'Enabled', 'Total']],
         body: perHeadData,
@@ -99,8 +100,8 @@ const BudgetCalculator = () => {
       });
 
       const fixedData = fixedItems.map(item => [item.name, formatCurrency(item.cost), item.enabled ? 'Yes' : 'No', formatCurrency(item.enabled ? item.cost : 0)]);
-      doc.autoTable({
-        startY: doc.autoTable.previous.finalY + 10,
+      autoTable(doc, {
+        startY: (doc.lastAutoTable?.finalY || 45) + 10,
         head: [['Fixed Cost Items', 'Cost', 'Enabled', 'Total']],
         body: fixedData,
         theme: 'striped',
@@ -113,8 +114,8 @@ const BudgetCalculator = () => {
         [`Service Charge (${serviceCharge}%)`, formatCurrency(totals.serviceChargeAmount)],
         ['Grand Total', formatCurrency(totals.grandTotal)],
       ];
-      doc.autoTable({
-        startY: doc.autoTable.previous.finalY + 10,
+      autoTable(doc, {
+        startY: (doc.lastAutoTable?.finalY || 45) + 10,
         body: summaryData,
         theme: 'plain',
         styles: { fontSize: 12 },


### PR DESCRIPTION
## Summary
- switch PDF generators to call `jspdf-autotable` directly so tables render in dev builds
- add a shared helper to reuse the `autoTable` invocation and final Y calculations
- update the budget calculator export to use the new approach when building tables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce8e33f5308323a8efcceadddfd35c